### PR TITLE
Add possibility to use environment  variables

### DIFF
--- a/settings.py.sample
+++ b/settings.py.sample
@@ -1,27 +1,28 @@
 #!/usr/bin/python3
+from os import getenv
 
 ##########################################
 # Nextcloud settings
 
-url='https://example.com/ocs/v2.php/apps/notifications/api/v2/notifications'
-user='username'
-pw='secretpw'
+url = getenv('NEXTCLOUD_URL', 'https://nextcloudexample.com')
+user = getenv('NEXTCLOUD_USER', 'username')
+pw = getenv('NEXTCLOUD_PASSWORD', 'secretpw')
 
 ##########################################
 # Gotify settings
 
-urlpush='https://example.com/message'
-token='TOKEN'
+urlpush = getenv('GOTIFY_URL', 'https://gotifyexample.com')
+token = getenv('GOTIFY_TOKEN', 'TOKEN')
 
 ##########################################
 # General settings
 
 # Frequency for checking new notifications
-delay=30
+delay = int(getenv('NOTIFICATION_DELAY', 30))
 
 # Priority for the notification sent through this channel
 # If this is set below 10, there won't be any sound when receiving a message
-notification_priority='10'
+notification_priority = getenv('NOTIFICATION_PRIORITY', '10')
 
 # Optional log file
-log_file = 'logs/gotify-nc.log'
+log_file = getenv('LOG_PATH', 'logs/gotify-nc.log')


### PR DESCRIPTION
You can use environment variables instead of storing passwords in
config.py as plaintext. Note that settings.py is still needed, because
this file reads the  environment variables.

Changes in settings.py:
- Only the domain has to be specified for the URLs. Previously you used
'https://example.com/ocs/v2.php/apps/notifications/api/v2/notifications'
now you only specify 'https://example.com'. This is valid for both
Nextcloud and Gotify URL as well.

Some minimal adjustments in push_msg.py:
- Remove unused json import
- Use single quote globally
- Remove unnecessary whitespace character
- Break some long lines